### PR TITLE
Update support for ctypes >= 0.12.0

### DIFF
--- a/lib/memcpy.ml
+++ b/lib/memcpy.ml
@@ -24,7 +24,8 @@ type unsafe = Unsafe
 type (_, _) spec =
     OCaml_bytes : (safe, Bytes.t) spec
   | Bigarray :
-      < ba_repr : 'a; bigarray : 'b; carray : 'c; dims : 'd; element : 'e > bigarray_class *
+      < ba_repr : 'a; bigarray : 'b; carray : 'c; dims : 'd; element : 'e;
+        layout: Bigarray.c_layout > bigarray_class *
       'd *
       ('e, 'a) Bigarray.kind ->
     (safe, 'b) spec

--- a/lib/memcpy.mli
+++ b/lib/memcpy.mli
@@ -30,7 +30,8 @@ val ocaml_bytes : (safe, Bytes.t) spec
 (** A specification for OCaml's bytes type *)
 
 val bigarray :
-  < ba_repr : 'a; bigarray : 'b; carray : 'c; dims : 'd; element : 'e > bigarray_class ->
+  < ba_repr : 'a; bigarray : 'b; carray : 'c; dims : 'd; element : 'e;
+    layout: Bigarray.c_layout > bigarray_class ->
   'd -> ('e, 'a) Bigarray.kind -> (safe, 'b) spec
 (** A specification for a bigarray type *)
 

--- a/opam
+++ b/opam
@@ -12,7 +12,7 @@ install: [[make "install"]]
 build-test: [[make "test"]]
 remove: [["ocamlfind" "remove" "memcpy"]]
 depends: [
-   "ctypes" {>= "0.4.0"}
+   "ctypes" {>= "0.12.0"}
    "ounit" {test}
    "ocamlfind" {build}
    "ocamlbuild" {build}


### PR DESCRIPTION
Ctypes 0.12.0 adds a new field, `layout`, to the `bigarray_class` index.  See
https://github.com/ocamllabs/ocaml-ctypes/pull/523