### PR TITLE
ctypes: fix compatibility with 0.21.0

### DIFF
--- a/lib/_tags
+++ b/lib/_tags
@@ -1,3 +1,3 @@
-true: package(ctypes)
+true: package(ctypes.stubs)
 <memcpy_stubs.c>: use_ctypes
 <*.{cma,cmxa}>: use_memcpy_stubs


### PR DESCRIPTION
In ctypes < 0.21.0, the `ctypes` and `ctypes.stubs` libraries were installed in the same directory, so depending on one would make the other one visible.
ctypes 0.21.0 installs them in different directories so this makes it an error. memcpy actually uses `ctypes.stubs` so it should depend on it.
